### PR TITLE
Added timeout fix for axiosInstance

### DIFF
--- a/src/helpers/fetch/fetchFromUri.ts
+++ b/src/helpers/fetch/fetchFromUri.ts
@@ -34,6 +34,7 @@ export default async (options: FetchFromUriOptions) => {
     const requestOptions = {
       method,
       url: encodeURI(uri),
+      timeout: 10000,
       ...headers && { headers },
       ...auth && { auth },
       ...data && { data },


### PR DESCRIPTION
I do not remember, have I created this issue or not, but `defaultAxios` doesn't have timeout at all.

What problem it could generate? If battle.net endpoint somehow doesn't reply you back or packets will be missing, you will never receive the response at all.

For example, if I request data about 10 characters one-by-one, and on the 3rd character request I don't receive a reply from API, well it will block the main thread. Literally forever.

So this little string adds a timeout to axios instance, which will reject the request by timeout. I also understood that according to [this issue](https://github.com/lukemnet/blizzapi/issues/165) the axios will be removed by the native `fetch` method, which doesn't support the timeouts at all. But by creating this pull request I just notify that the problem exists and it deserves any attention.

Okay, to be honest, according [to this issue thread](https://github.com/whatwg/fetch/issues/20) in the `fetch` repo most of the devs think about the *timeout* option as userland, so in that case, it should be implemented manually.

