### PR TITLE
Feature 'last-modified' headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,7 @@ src/*.js
 # generated docs
 docs/
 
+# WebStormIDE
+.idea
+
 package-lock.json

--- a/src/helpers/bnet/query.ts
+++ b/src/helpers/bnet/query.ts
@@ -1,13 +1,8 @@
 import { endpoint as validateEndpoint } from '../validators';
-import { getAccessToken, validateAccessToken }  from '../oauth';
+import { getAccessToken, validateAccessToken } from '../oauth';
 import { getApiHostByRegion } from '../../utils/api';
 import { fetchFromUri } from '../fetch';
-import {
-  RegionIdOrName,
-  AccessToken,
-  AccessTokenOptions,
-  QueryOptions,
-} from '../../types';
+import { AccessToken, AccessTokenOptions, QueryOptions, RegionIdOrName } from '../../types';
 
 interface BattleNetQueryOptions {
   region: RegionIdOrName;
@@ -69,8 +64,7 @@ export default async (queryOptions: BattleNetQueryOptions) => {
   }
 
   try {
-    const data = await queryWithAccessToken(queryOptions, accessToken);
-    return data;
+    return await queryWithAccessToken(queryOptions, accessToken);
   } catch (error) {
     if (error.response && error.response.status === 401) {
       onAccessTokenExpired && onAccessTokenExpired();

--- a/src/helpers/fetch/fetchFromUri.ts
+++ b/src/helpers/fetch/fetchFromUri.ts
@@ -44,6 +44,9 @@ export default async (options: FetchFromUriOptions) => {
     };
 
     const response = await axios.request(requestOptions);
+    if (response && response.headers) {
+      Object.assign(response.data, { lastModified: response.headers['last-modified'] });
+    }
     return response.data;
   } catch (error) {
     throw error;


### PR DESCRIPTION
After yesterday's tests, I improve the original library a bit. Since Blizzard doesn't return a `lastModifed` value in response and uses headers for it, I allow adding myself this little feature which adds to `response.data` a `last-modified` value from header on exist.

I also fix `query.tx` since TSLint said that:
```
    const data = await queryWithAccessToken(queryOptions, accessToken);
    return data;
```
could be improved with: `return await queryWithAccessToken(queryOptions, accessToken);`

As for the `.gitignore` I work in JetBrains's Webstorm IDE, that why `.idea` has been automatically added to it. If it's a problem, tell me, and I'll revert it, and make PR via cherry-picking.